### PR TITLE
Add editable trivia with postgresql

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,1 +1,4 @@
+NODE_ENV=development
+BOT_COMMAND_PREFIX=?
+DATABASE_URL=postgres://postgres:c8bot@localhost:5432/postgres
 DISCORD_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,8 @@ typings/
 
 # dotenv environment variables file
 .env
-.env.test
+.env.*
+!.env.dist
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Discord botti. MVP announcementtii ja muut random paskaa
 
 ### Requirements
 * Node 14.x: recommend [nvm](https://github.com/nvm-sh/nvm) on linux and macOS
+* Docker desktop for compose, for local database setup
+  * or docker compose directly, see [install instructions](https://docs.docker.com/compose/install/)
 
 ### Optional requirements
 
@@ -17,6 +19,19 @@ Optional requirements for better performance of the bot.
 * Make: `brew install make`/`sudo apt install make`
 * GCC: `brew install gcc`/`sudo apt install gcc`
 * G++: `brew install g++`/`sudo apt install g++`
+
+### Useful VSCode plugins
+
+* [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+* [XO](https://marketplace.visualstudio.com/items?itemName=samverschueren.linter-xo)
+#### Windows
+
+See [this article](https://code.visualstudio.com/blogs/2020/07/01/containers-wsl#_new-era-of-virtualization)
+for a guide on how to use VSCode, WSL2 and Docker desktop.
+
+* [Remote - WSL](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl)
+* [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+* [Docker](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
 
 ### Configure and run 
 
@@ -31,6 +46,13 @@ npm install
 cp .env.dist .env
 # Add required .env 
 $EDITOR .env
+
+# Run database
+docker-compose up
+
+# Create db schemas and seed test data
+npm run migrate
+npm run seed
 
 # Run dev server with auto-reload on changes
 npm run dev

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,16 @@
+version: '3.1'
+
+services:
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: c8bot
+    ports:
+      - 5432:5432
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080

--- a/package-lock.json
+++ b/package-lock.json
@@ -514,6 +514,11 @@
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
       "dev": true
     },
+    "@types/nanoid-dictionary": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/nanoid-dictionary/-/nanoid-dictionary-4.2.0.tgz",
+      "integrity": "sha512-DyQddKC2AYsInXBMqKSwhom4gpouV8SF1smsCPSzR8hp20vZJ5o5Yxg7qXThCHwr/H6VMq01UArEGbF0q2FXig=="
+    },
     "@types/node": {
       "version": "14.14.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
@@ -661,7 +666,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1272,6 +1276,11 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -1862,11 +1871,15 @@
         "time-zone": "^1.0.0"
       }
     },
+    "db-errors": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/db-errors/-/db-errors-0.2.3.tgz",
+      "integrity": "sha512-OOgqgDuCavHXjYSJoV2yGhv6SeG8nk42aoCSoyXLZUH7VwFG27rxbavU1z+VrZbZjphw5UkDQwUlD21MwZpUng=="
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       },
@@ -1874,8 +1887,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -2119,6 +2131,24 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
+    "dotenv-cli": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-4.0.0.tgz",
+      "integrity": "sha512-ByKEec+ashePEXthZaA1fif9XDtcaRnkN7eGdBDx3HHRjwZ/rA1go83Cbs4yRrx3JshsCf96FjAyIA2M672+CQ==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1",
+        "dotenv": "^8.1.0",
+        "dotenv-expand": "^5.1.0",
+        "minimist": "^1.1.3"
+      }
+    },
+    "dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+      "dev": true
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -2273,8 +2303,7 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-goat": {
       "version": "2.1.1",
@@ -2771,6 +2800,11 @@
       "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -3048,8 +3082,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -3074,8 +3107,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3211,8 +3243,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -3275,6 +3306,11 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
+    },
+    "getopts": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.2.5.tgz",
+      "integrity": "sha512-9jb7AW5p3in+IiJWhQiZmmwkpLaR/ccTWdWQCtZM66HJcHHLegowh4q4tSD7gouUyeNvFWRavfK9GXosQHDpFA=="
     },
     "glob": {
       "version": "7.1.6",
@@ -3380,7 +3416,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -3614,8 +3649,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "2.0.0",
@@ -3720,7 +3754,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
       "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -4091,8 +4124,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4133,6 +4165,43 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
+    },
+    "knex": {
+      "version": "0.95.4",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.4.tgz",
+      "integrity": "sha512-IwUcHr6AkZPL707mJCOal1P4jlgxKMy17IMjJm5W23yrkM1jO2/APBM1eyw/MhQ61w8T7NpzGD+LEkr8M46mWw==",
+      "requires": {
+        "colorette": "1.2.1",
+        "commander": "^7.1.0",
+        "debug": "4.3.1",
+        "escalade": "^3.1.1",
+        "esm": "^3.2.25",
+        "getopts": "2.2.5",
+        "interpret": "^2.2.0",
+        "lodash": "^4.17.21",
+        "pg-connection-string": "2.4.0",
+        "rechoir": "^0.7.0",
+        "resolve-from": "^5.0.0",
+        "tarn": "^3.0.1",
+        "tildify": "2.0.0"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+          "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
+        },
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+        },
+        "interpret": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+          "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
+        }
+      }
     },
     "latest-version": {
       "version": "5.1.0",
@@ -4288,8 +4357,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -4731,6 +4799,16 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
+    "nanoid": {
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
+      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ=="
+    },
+    "nanoid-dictionary": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/nanoid-dictionary/-/nanoid-dictionary-4.3.0.tgz",
+      "integrity": "sha512-Xw1+/QnRGWO1KJ0rLfU1xR85qXmAHyLbE3TUkklu9gOIDburP6CsUnLmTaNECGpBh5SHb2uPFmx0VT8UPyoeyw=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -5168,6 +5246,15 @@
         "has": "^1.0.3"
       }
     },
+    "objection": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/objection/-/objection-2.2.15.tgz",
+      "integrity": "sha512-ZOLJDigE9Z2ppk3C//S2fcWL6ph2jUe6Cwl0CEpslTZegnnOeG6RPIV80nhPAaghWjl/8F2kox/w89VVBN4ccg==",
+      "requires": {
+        "ajv": "^6.12.6",
+        "db-errors": "^0.2.3"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5340,6 +5427,11 @@
         }
       }
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -5423,8 +5515,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-type": {
       "version": "4.0.0",
@@ -5443,6 +5534,67 @@
         "ripemd160": "^2.0.1",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "pg": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.6.0.tgz",
+      "integrity": "sha512-qNS9u61lqljTDFvmk/N66EeGq3n6Ujzj0FFyNMGQr6XuEv4tgNTXvJQTfJdcvGit5p5/DWPu+wj920hAJFI+QQ==",
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.3.0",
+        "pg-protocol": "^1.5.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "dependencies": {
+        "pg-connection-string": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+          "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+        }
+      }
+    },
+    "pg-connection-string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
+      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-pool": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.3.0.tgz",
+      "integrity": "sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg=="
+    },
+    "pg-protocol": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
+      "requires": {
+        "split2": "^3.1.1"
       }
     },
     "picomatch": {
@@ -5541,6 +5693,29 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -5648,8 +5823,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.1.1",
@@ -5867,7 +6041,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -5881,6 +6054,14 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "rechoir": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
+      "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+      "requires": {
+        "resolve": "^1.9.0"
       }
     },
     "redent": {
@@ -5978,7 +6159,6 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
       "requires": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -5996,8 +6176,7 @@
     "resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -6451,6 +6630,14 @@
         "extend-shallow": "^3.0.0"
       }
     },
+    "split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "requires": {
+        "readable-stream": "^3.0.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6611,7 +6798,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       },
@@ -6619,8 +6805,7 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
@@ -6774,6 +6959,11 @@
       "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
       "dev": true
     },
+    "tarn": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.1.tgz",
+      "integrity": "sha512-6usSlV9KyHsspvwu2duKH+FMUhqJnAh6J5J/4MITl8s94iSUQTLkJggdiewKv4RyARQccnigV48Z+khiuVZDJw=="
+    },
     "temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -6797,6 +6987,11 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "tildify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
+      "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw=="
     },
     "time-zone": {
       "version": "1.0.0",
@@ -7151,7 +7346,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -7224,8 +7418,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -7656,8 +7849,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -6,16 +6,20 @@
     "node": ">= 14.16 <15"
   },
   "scripts": {
-    "dev": "nodemon",
+    "dev": "npx nodemon",
     "start": "node --unhandled-rejections=strict build/src/index.js",
     "clean": "rimraf coverage build tmp",
-    "build": "tsc -p tsconfig.release.json",
-    "build:watch": "tsc -w -p tsconfig.release.json",
-    "test": "ava",
-    "test:watch": "ava --watch",
-    "format": "prettier --config ./.prettierrc.json --ignore-path ./.prettierignore --write",
-    "lint": "xo",
-    "lint:fix": "xo --fix",
+    "build": "npx tsc -p tsconfig.release.json",
+    "build:watch": "npx tsc -w -p tsconfig.release.json",
+    "test": "npx ava",
+    "test:watch": "npx ava --watch",
+    "format": "npx prettier --config ./.prettierrc.json --ignore-path ./.prettierignore --write",
+    "lint": "npx xo",
+    "lint:fix": "npx xo --fix",
+    "migrate": "cd src && npx dotenv-cli dotenv -e ../.env npx knex migrate:latest",
+    "rollback": "cd src && npx dotenv-cli dotenv -e ../.env npx knex migrate:rollback",
+    "seed": "cd src && npx dotenv-cli dotenv -e ../.env npx knex seed:run",
+    "seed:prd": "cd build/src && npx dotenv-cli dotenv -e ../.env.prd npx knex seed:run",
     "prepare": "husky install"
   },
   "repository": {
@@ -34,6 +38,7 @@
   "devDependencies": {
     "@types/node": "^14.14.41",
     "ava": "^3.15.0",
+    "dotenv-cli": "^4.0.0",
     "husky": "^6.0.0",
     "lint-staged": "^10.5.4",
     "nodemon": "^2.0.7",
@@ -44,9 +49,15 @@
     "xo": "^0.38.2"
   },
   "dependencies": {
+    "@types/nanoid-dictionary": "^4.2.0",
     "discord.js": "^12.5.3",
     "dotenv": "^8.2.0",
+    "knex": "^0.95.4",
     "libsodium-wrappers": "^0.7.9",
+    "nanoid": "^3.1.22",
+    "nanoid-dictionary": "^4.3.0",
+    "objection": "^2.2.15",
+    "pg": "^8.6.0",
     "tslib": "^2.2.0",
     "zlib-sync": "^0.1.7"
   },
@@ -56,7 +67,28 @@
     "utf-8-validate": "^5.0.4"
   },
   "xo": {
-    "prettier": true
+    "prettier": true,
+    "unicorn/filename-case": "none",
+    "overrides": [
+      {
+        "files": "src/models/*.ts",
+        "rules": {
+          "unicorn/filename-case": [
+            "error",
+            {"case": "pascalCase"}
+          ]
+        }
+      },
+      {
+        "files": ["src/migrations/*.ts", "src/seeds/**/*.ts"],
+        "rules": {
+          "unicorn/filename-case": [
+            "error",
+            {"case": "snakeCase"}
+          ]
+        }
+      }
+    ]
   },
   "lint-staged": {
     "*.ts": [
@@ -84,6 +116,9 @@
       "test/"
     ],
     "ext": "ts,js,jsx,json",
-    "exec": "node --require ts-node/register --unhandled-rejections=strict ./src/index.ts"
+    "exec": "node --require ts-node/register --unhandled-rejections=strict ./src/index.ts",
+    "env": {
+      "NODE_ENV": "development"
+    }
   }
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,146 @@
+import {
+  DMChannel,
+  NewsChannel,
+  TextChannel,
+  Message,
+  MessageEmbed,
+} from 'discord.js';
+import config from '../config';
+import Trivia from '../models/Trivia';
+
+const VITSIT = [
+  'Sul on pieni',
+  'Mitä tähän nyt sanois..',
+  'Heikki on komee',
+  'Miksi naiset panostavat enemmän ulkonäköönsä kuin älyynsä? Koska miehet ovat pääsääntöisesti tyhmiä mutta eivät sokeita.',
+  'Mitä yhteistä on gynegologilla ja ammattimuusikolla? Kummallakin se on alkanut harrastuksesta!',
+  'Elämäni tarkoitus on olla varoittavana esimerkkinä muille.',
+  'Mitä gynekologi sanoi ruokatunnin jälkeen? No mihis vittuun sitä jäikään',
+  'Miksi Röllin vene upposi? Siitä puuttui tilipitappi',
+];
+
+export async function handleCommand(message: Message) {
+  // Console.log(`${message.author.username} lähetti viestin: ${message.content}`);
+
+  const content = message.content.slice(config.BotCommandPrefix.length);
+
+  if (content === 'help') {
+    await printHelp(message.channel);
+    return;
+  }
+
+  if (content === 'test') {
+    await message.reply('Toimii madafaka');
+    return;
+  }
+
+  if (content === 'vitsi') {
+    await message.channel.send(
+      VITSIT[Math.floor(Math.random() * VITSIT.length)],
+    );
+    return;
+  }
+
+  if (content === 'categories') {
+    const categories = await Trivia.query()
+      .select('category')
+      .count({
+        categoryCount: 'category',
+      })
+      .groupBy('category');
+
+    const categoryList = categories
+      .map((trivia) => `_${trivia.category}_ ${trivia.categoryCount!}`)
+      .join('\n');
+
+    await message.channel.send(`**Available categories** (${categories.length})
+${categoryList}`);
+    return;
+  }
+
+  if (content.startsWith('del')) {
+    const match = /del (\S*)$/.exec(content);
+
+    if (!match || !match[1]) {
+      await printHelp(message.channel);
+      return;
+    }
+
+    const deletedCount = await Trivia.query().deleteById(match[1]);
+
+    await (deletedCount === 1 ? message.react('✅') : message.react('❌'));
+    return;
+  }
+
+  if (content.startsWith('trivia')) {
+    const match = /trivia (\S*)( (.*))?$/.exec(content);
+
+    if (!match || !match[1]) {
+      await printHelp(message.channel);
+      return;
+    }
+
+    if (match[2]) {
+      // Save given new content
+      const trivia = await Trivia.query()
+        .insert({
+          category: match[1],
+          content: match[3],
+          author: message.author.username,
+        })
+        .returning('*');
+
+      await message.react('✅');
+      await sendPersonTrivia(message.channel, trivia);
+    } else {
+      // No new content found, get random trivia
+      const trivia = await Trivia.query()
+        // Inner query gives row numbers randomly and outer selects randomly chosen first row
+        .from(
+          Trivia.query()
+            .select(
+              '*',
+              Trivia.raw('row_number() OVER (ORDER BY random()) as rn'),
+            )
+            .where('category', 'ILIKE', match[1])
+            .as('t'),
+        )
+        .where('rn', 1);
+
+      if (trivia.length === 0) {
+        await message.react('❌');
+        await message.channel.send(`No trivia found for category: ${match[1]}`);
+        return;
+      }
+
+      await sendPersonTrivia(message.channel, trivia[0]);
+    }
+  }
+}
+
+async function printHelp(channel: TextChannel | DMChannel | NewsChannel) {
+  await channel.send(
+    `Test: ${config.BotCommandPrefix}test
+Joke: ${config.BotCommandPrefix}vitsi
+Get random trivia: ${config.BotCommandPrefix}trivia <category>
+Add new trivia: ${config.BotCommandPrefix}trivia <category> <content>
+List categories: ${config.BotCommandPrefix}categories
+Delete trivia by id: ${config.BotCommandPrefix}del <triviaId>`,
+  );
+}
+
+async function sendPersonTrivia(
+  channel: TextChannel | DMChannel | NewsChannel,
+  trivia: Trivia,
+) {
+  const embed = new MessageEmbed()
+    .setColor('#0099ff')
+    .setTitle(
+      `${trivia.category.slice(0, 1).toUpperCase()}${trivia.category.slice(1)}`,
+    )
+    .setDescription(trivia.content)
+    .setFooter(`Author: ${trivia.author}, ID: ${trivia.id}`)
+    .setTimestamp(trivia.createdAt);
+
+  return channel.send(embed);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,15 +1,25 @@
 import dotenv from 'dotenv';
 
 dotenv.config();
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
-if (!process.env.DISCORD_TOKEN) {
-  throw new Error(
-    'No discord token configured, copy .env.dist to .env and set DISCORD_TOKEN',
-  );
+if (
+  process.env.NODE_ENV !== 'development' &&
+  process.env.NODE_ENV !== 'production'
+) {
+  throw new Error('unknown NODE_ENV');
 }
 
 const config = {
+  NodeEnv: process.env.NODE_ENV,
   DiscordToken: process.env.DISCORD_TOKEN,
+  BotCommandPrefix: process.env.BOT_COMMAND_PREFIX ?? '.',
 };
+
+for (const [key, value] of Object.entries(config)) {
+  if (!value) {
+    throw new Error(`Missing config variable ${key}`);
+  }
+}
 
 export default config;

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -1,0 +1,15 @@
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      NODE_ENV: 'development' | 'production';
+      PWD: string;
+      DATABASE_URL: string;
+      DISCORD_TOKEN: string;
+    }
+  }
+}
+
+// If this file has no import/export statements (i.e. is a script)
+// convert it into a module by adding an empty export statement.
+const def = {};
+export default def;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,34 +1,24 @@
-import config from './config';
 import Discord from 'discord.js';
+import knex from 'knex';
+import {Model as m} from 'objection';
+
+import _ from './environment.d';
+import {handleCommand} from './commands';
+import config from './config';
+import knexConfig from './knexfile';
 
 const client = new Discord.Client();
 
-const heiksman = [
-  'Heikki on likanen rotta t.toffitee',
-  'Se haisee..',
-  '0,5 piuhalle bless !',
-  'Pieni pippeli',
-  'Vuoden vegaani',
-  'Kissamies 2.0',
-  'Joulupukkiki on kateellinen sen parralle',
-  'Vittuku ei oo massii..',
-  'MENNÄÄ ANTAA JES JES JES',
-  'Ei ei älä selkää, sattuu!!',
-  'Poketkaa sit ku on tilaa...'
-];
-
-const jokes = [
-  'Sul on pieni',
-  'Mitä tähän nyt sanois..',
-  'Heikki on komee',
-  'Miksi naiset panostavat enemmän ulkonäköönsä kuin älyynsä? Koska miehet ovat pääsääntöisesti tyhmiä mutta eivät sokeita.',
-  'Mitä yhteistä on gynegologilla ja ammattimuusikolla? Kummallakin se on alkanut harrastuksesta!',
-  'Elämäni tarkoitus on olla varoittavana esimerkkinä muille.',
-  'Mitä gynekologi sanoi ruokatunnin jälkeen? No mihis vittuun sitä jäikään',
-  'Miksi Röllin vene upposi? Siitä puuttui tilipitappi',
-];
-
 async function main() {
+  // Connect to database
+  const db = knex(knexConfig);
+  m.knex(db);
+  if (process.env.NODE_ENV === 'production') {
+    await db.migrate.latest();
+  }
+
+  await db.raw('SELECT 1;');
+
   // Login to discord
   await client.login(config.DiscordToken);
 
@@ -37,24 +27,8 @@ async function main() {
   });
 
   client.on('message', async (message) => {
-    console.log(
-      `${message.author.username} lähetti viestin: ${message.content}`,
-    );
-
-    if (message.content === '!test') {
-      await message.reply('Toimii madafaka');
-    }
-
-    if (message.content === '!vitsi') {
-      await message.channel.send(
-        jokes[Math.floor(Math.random() * jokes.length)],
-      );
-    }
-
-    if (message.content === '!heikki') {
-      await message.channel.send(
-        heiksman[Math.floor(Math.random() * heiksman.length)],
-      );
+    if (message.content.startsWith(config.BotCommandPrefix)) {
+      await handleCommand(message);
     }
   });
 }

--- a/src/knexfile.ts
+++ b/src/knexfile.ts
@@ -1,0 +1,40 @@
+import {join} from 'node:path';
+import _ from './environment.d';
+
+export default {
+  development: {
+    client: 'pg',
+    connection: `${process.env.DATABASE_URL}`,
+    pool: {
+      min: 2,
+      max: 5,
+    },
+    migrations: {
+      directory: './migrations',
+      extension: 'ts',
+    },
+    seeds: {
+      directory: './seeds/dev',
+      extension: 'ts',
+    },
+  },
+  production: {
+    client: 'pg',
+    connection: {
+      connectionString: `${process.env.DATABASE_URL}`,
+      ssl: {rejectUnauthorized: false},
+    },
+    pool: {
+      min: 2,
+      max: 5,
+    },
+    migrations: {
+      directory: join(__dirname, '/migrations'),
+      extension: 'js',
+    },
+    seeds: {
+      directory: join(__dirname, '/seeds/dev'),
+      extension: 'js',
+    },
+  },
+}[process.env.NODE_ENV];

--- a/src/migrations/20210423231235_trivia.ts
+++ b/src/migrations/20210423231235_trivia.ts
@@ -1,0 +1,20 @@
+import {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema
+    .raw('CREATE EXTENSION IF NOT EXISTS "pg_trgm"')
+    .createTable('trivia', (table) => {
+      table.string('id').primary();
+      table.string('createdAt').notNullable().defaultTo(knex.raw('now()'));
+      table.string('author', 255).notNullable();
+      table.string('category', 255).notNullable();
+      table.string('content').notNullable();
+    })
+    .raw(
+      'CREATE INDEX triviaCategoryIndex on trivia USING GIN (category gin_trgm_ops)',
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTableIfExists('trivia');
+}

--- a/src/model-utils/model-generate-id.ts
+++ b/src/model-utils/model-generate-id.ts
@@ -1,0 +1,23 @@
+import {Model, QueryContext} from 'objection';
+import {customAlphabet} from 'nanoid/async';
+import {nolookalikes} from 'nanoid-dictionary';
+
+type Constructor<T> = new (...args: any[]) => T;
+
+type Plugin = <M extends Constructor<Model>>(modelClass: M) => M;
+
+const generateId = customAlphabet(nolookalikes, 12);
+
+const GenerateIds: Plugin = (Model) => {
+  return class extends Model {
+    id!: string;
+
+    async $beforeInsert(context: QueryContext) {
+      await super.$beforeInsert(context);
+
+      this.id = this.id || (await generateId());
+    }
+  };
+};
+
+export default GenerateIds;

--- a/src/models/Trivia.ts
+++ b/src/models/Trivia.ts
@@ -1,0 +1,33 @@
+import {Model, Pojo} from 'objection';
+
+import generateIds from '../model-utils/model-generate-id';
+
+export default class Trivia extends generateIds(Model) {
+  static tableName = 'trivia';
+
+  static jsonSchema = {
+    type: 'object',
+    required: ['author', 'category', 'content'],
+
+    properties: {
+      author: {type: 'string', minLength: 1, maxLength: 64},
+      category: {type: 'string', minLength: 1, maxLength: 64},
+      content: {type: 'string', minLength: 1, maxLength: 1024},
+    },
+  };
+
+  id!: string;
+  author!: string;
+  category!: string;
+  content!: string;
+  categoryCount?: number;
+  createdAt!: Date;
+
+  $formatJson(json: Pojo) {
+    json = super.$formatJson(json);
+
+    json.createdAt = new Date(json.createdAt);
+
+    return json;
+  }
+}

--- a/src/seeds/dev/trivia_heikki.ts
+++ b/src/seeds/dev/trivia_heikki.ts
@@ -1,0 +1,76 @@
+import {Knex} from 'knex';
+
+export async function seed(knex: Knex): Promise<void> {
+  // Deletes ALL existing entries
+  await knex('trivia').del();
+
+  // Inserts seed entries
+  await knex('trivia').insert([
+    {
+      id: '6LnDGkTr4gVh',
+      author: 'toffitee',
+      category: 'Heikki',
+      content: 'Heikki on likanen rotta',
+    },
+    {
+      id: 'XTcnCieRWAaX',
+      author: 'aitogee',
+      category: 'Heikki',
+      content: 'Se haisee..',
+    },
+    {
+      id: '4pPyRYAeGtG3',
+      author: 'archive',
+      category: 'Heikki',
+      content: '0,5 piuhalle bless !',
+    },
+    {
+      id: 'GGCGP9WMVRUX',
+      author: 'archive',
+      category: 'Heikki',
+      content: 'Pieni pippeli',
+    },
+    {
+      id: 'dDPQpTeLPQDU',
+      author: 'archive',
+      category: 'Heikki',
+      content: 'Vuoden vegaani',
+    },
+    {
+      id: 'EkYwP3NMhGCh',
+      author: 'archive',
+      category: 'Heikki',
+      content: 'Kissamies 2.0',
+    },
+    {
+      id: 'BC9i9FdBhdNh',
+      author: 'archive',
+      category: 'Heikki',
+      content: 'Joulupukkiki on kateellinen sen parralle',
+    },
+    {
+      id: 'bLDQyGnyJEJH',
+      author: 'archive',
+      category: 'Heikki',
+      content: 'Vittuku ei oo massii..',
+    },
+    {
+      id: 'fCbetXkTjmaA',
+      author: 'tapppi',
+      category: 'Heikki',
+      content: 'MENNÄÄ ANTAA JES JES JES',
+    },
+    {
+      id: 'RiHLhpM6p4Bn',
+      author: 'tapppi',
+      category: 'Heikki',
+      content: 'Ei ei älä selkää, sattuu!!',
+    },
+    {
+      id: 'hXtiffGKkK4g',
+      author: 'snakkeboi',
+      category: 'Heikki',
+      content: 'Poketkaa sit ku on tilaa...',
+    },
+  ]);
+}


### PR DESCRIPTION
* Add [`objection` ORM](https://vincit.github.io/objection.js/) for working with PostgreSQL
* Add `knex` based migrations and some test data and instructions in README for using it (`docker-compose up && npm run migrate && npm run seed`)
* `model-utils` folder has utility class that generates short IDs for new rows in e.g. `Trivia` class
* Default local command prefix `?`, default deployed bot prefix `.`
* Move commands to `src/commands/index.ts`
* `.help` for listing commands
* Add trivia functionality:
  * `Trivia` class in `src/models/Trivia.ts` and the relevant migration in `src/migrations`
  * `.trivia <category>` command for getting trivia
  * `.trivia <category> <content>` for adding new trivia
  * `.categories` for listing trivia categories
  * `.del <triviaId>` for deleting trivia
